### PR TITLE
Support for PHP 5 & PHP 7 switching with Apache

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,11 @@
 	AddHandler application/x-httpd-php .php
 	```
 
+3. You can use `PHP_VERSION_MAJOR` variable in Apache configuration file. This is useful when you switch between PHP 5 and new PHP 7 version:
+	```
+	LoadModule php${PHP_VERSION_MAJOR}_module "C:/Web/Soft/PHP/active/php${PHP_VERSION_MAJOR}apache2_4.dll"
+	```
+
 ### Nginx + PHP FastCGI
 
 1. Update `HttpServerProcessPath` option in `PhpVersionSwitcher.exe.config` to contain path to `nginx.exe`.

--- a/src/app/VersionsManager.cs
+++ b/src/app/VersionsManager.cs
@@ -9,6 +9,8 @@ namespace PhpVersionSwitcher
 {
 	internal class VersionsManager
 	{
+		private const string SystemEnvironmentVariableName = "PHP_VERSION_MAJOR";
+
 		private string phpBaseDir;
 
 		private IList<IProcessManager> serverManagers;
@@ -83,6 +85,11 @@ namespace PhpVersionSwitcher
 			await this.UpdateSymlink(version);
 			await this.UpdatePhpIni(version);
 
+			if (this.serverManagers.OfType<ServiceManager>().Any())
+			{
+				this.SetSystemEnvironmentVariable(version);
+			}
+
 			await Task.WhenAll(this.serverManagers
 				.Where((server, i) => this.running[i])
 				.Select(server => server.Start())
@@ -154,6 +161,12 @@ namespace PhpVersionSwitcher
 
 				Symlinks.CreateDir(symlink, target);
 			});
+		}
+
+		private void SetSystemEnvironmentVariable(Version version)
+		{
+			var phpVersionMajor = version.Major;
+			Environment.SetEnvironmentVariable(SystemEnvironmentVariableName, phpVersionMajor.ToString(), EnvironmentVariableTarget.Machine);
 		}
 	}
 }


### PR DESCRIPTION
Solution for #14 

Not so clean solution, but works well. I use system environment variable because httpd server on Windows does not support `-D` parameter.